### PR TITLE
Remove stage in rvm class

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,10 +1,14 @@
 class rvm($version=undef, $install_rvm=true) {
-  stage { 'rvm-install': before => Stage['main'] }
 
   if $install_rvm {
-    class {
-      'rvm::dependencies': stage => 'rvm-install';
-      'rvm::system':       stage => 'rvm-install', version => $version;
+    class { 'rvm::dependencies': }
+
+    class { 'rvm::system':
+      version => $version;
     }
+
+    # NOTE: This relationship is also handled by
+    # Rvm::System/Exec['rvm::dependencies']
+    Class['rvm::dependencies'] -> Class['rvm::system']
   }
 }


### PR DESCRIPTION
This messes with our own build's stage ordering.  As the consumer of the rvm class I should be responsible for determining where the class is realized in our build.  That's not the job of the rvm class.
