### PR TITLE
aliasing passenger package dependencies causing dependency failures on Ubuntu 12.04 LTS

### DIFF
--- a/manifests/passenger/apache/ubuntu/post.pp
+++ b/manifests/passenger/apache/ubuntu/post.pp
@@ -17,7 +17,7 @@ class rvm::passenger::apache::ubuntu::post(
     creates   => "${gempath}/passenger-${version}/ext/apache2/mod_passenger.so",
     logoutput => 'on_failure',
     require   => [Rvm_gem['passenger'], Package['apache2', 'build-essential', 'apache2-prefork-dev',
-                                                  'libapr-dev', 'libaprutil-dev', 'libcurl4-openssl-dev']],
+                                                  'libapr1-dev', 'libaprutil1-dev', 'libcurl4-openssl-dev']],
     environment => [ 'HOME=/root', ],
   }
 

--- a/manifests/passenger/apache/ubuntu/pre.pp
+++ b/manifests/passenger/apache/ubuntu/pre.pp
@@ -4,7 +4,7 @@ class rvm::passenger::apache::ubuntu::pre {
   if ! defined(Package['apache2'])              { package { 'apache2':              ensure => present } }
   if ! defined(Package['build-essential'])      { package { 'build-essential':      ensure => present } }
   if ! defined(Package['apache2-prefork-dev'])  { package { 'apache2-prefork-dev':  ensure => present } }
-  if ! defined(Package['libapr1-dev'])          { package { 'libapr1-dev':          ensure => present, alias => 'libapr-dev' } }
-  if ! defined(Package['libaprutil1-dev'])      { package { 'libaprutil1-dev':      ensure => present, alias => 'libaprutil-dev' } }
+  if ! defined(Package['libapr1-dev'])          { package { 'libapr1-dev':          ensure => present } }
+  if ! defined(Package['libaprutil1-dev'])      { package { 'libaprutil1-dev':      ensure => present } }
   if ! defined(Package['libcurl4-openssl-dev']) { package { 'libcurl4-openssl-dev': ensure => present } }
 }


### PR DESCRIPTION
removing the aliases fixes the dependency failures
