### PR TITLE
ensuring that passenger-install-apache2-module is only called once per gem version

### DIFF
--- a/manifests/passenger/apache/ubuntu/post.pp
+++ b/manifests/passenger/apache/ubuntu/post.pp
@@ -14,7 +14,7 @@ class rvm::passenger::apache::ubuntu::post(
 
   exec { 'passenger-install-apache2-module':
     command   => "${binpath}rvm ${ruby_version} exec passenger-install-apache2-module -a",
-    creates   => "${gempath}/passenger-${version}/ext/apache2/mod_passenger.so",
+    creates   => "${gempath}/passenger-${version}/${objdir}/apache2/mod_passenger.so",
     logoutput => 'on_failure',
     require   => [Rvm_gem['passenger'], Package['apache2', 'build-essential', 'apache2-prefork-dev',
                                                   'libapr1-dev', 'libaprutil1-dev', 'libcurl4-openssl-dev']],


### PR DESCRIPTION
fixed output path checked to see if the module has already been generated
