### PR TITLE
Centos 5 also requires curl-devel

### DIFF
--- a/manifests/dependencies/centos.pp
+++ b/manifests/dependencies/centos.pp
@@ -11,6 +11,7 @@ class rvm::dependencies::centos {
     }
     /^5\..*/: {
       ensure_packages(['autoconf'])
+      ensure_packages(['curl-devel'])
     }
     default: {
       ensure_packages(['curl-devel'])


### PR DESCRIPTION
Currently on a bare Centos5 install Exec['system-rvm'] will fail as nothing requires curl to be installed.
