### PR TITLE
Fix for maestrodev issue #20 - rvmrc / rvm group

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,6 +2,7 @@ class rvm(
   $version=undef,
   $install_rvm=true,
   $install_dependencies=false,
+  $group='rvm',
   $system_users=[],
   $system_rubies={}) {
 
@@ -14,6 +15,7 @@ class rvm(
       }
     }
 
+    ensure_resource('group', $group, {'ensure' => 'present' })
     ensure_resource('class', 'rvm::rvmrc')
 
     class { 'rvm::system':


### PR DESCRIPTION
This is a fix for: https://github.com/maestrodev/puppet-rvm/issues/20

The following changes were made:
- Added $group parameter, defaulted to 'rvm'
- Copied Line 8 from system_user.pp to ensure rvm group is created.
