### PR TITLE
Increase apache install timeout

### DIFF
--- a/manifests/passenger/apache.pp
+++ b/manifests/passenger/apache.pp
@@ -8,7 +8,7 @@ class rvm::passenger::apache(
   $maxinstancesperapp = '0',
   $spawnmethod = 'smart-lv2',
   $proxy_url = undef,
-  $install_timeout = 300
+  $install_timeout = 600
 ) {
 
   class { 'rvm::passenger::gem':


### PR DESCRIPTION
On slower machines it seems that the building of the Apache passenger module times out, I have increased it to 600, although I feel this could easy need to be increased time on time again, a better solution would be a default / parameter which I'm happy to introduce in another branch if that's a preferred approach.
