### PR TITLE
Added insecure flag to rvm install script retriever

### DIFF
--- a/manifests/system.pp
+++ b/manifests/system.pp
@@ -19,7 +19,7 @@ class rvm::system(
 
   exec { 'system-rvm':
     path        => '/usr/bin:/usr/sbin:/bin',
-    command     => "/usr/bin/curl -sSL https://raw.github.com/wayneeseguin/rvm/master/binscripts/rvm-installer | \
+    command     => "/usr/bin/curl -ksSL https://raw.github.com/wayneeseguin/rvm/master/binscripts/rvm-installer | \
                     bash -s -- --version ${actual_version}",
     creates     => '/usr/local/rvm/bin/rvm',
     environment => $proxy_url ? { undef => undef, default => [ "http_proxy=${proxy_url}" , "https_proxy=${proxy_url}" ]},


### PR DESCRIPTION
fixes [this issue](https://github.com/maestrodev/puppet-rvm/issues/36)
