### PR TITLE
Make the autoupdate_flag a string to avoid this bug:

### DIFF
--- a/manifests/rvmrc.pp
+++ b/manifests/rvmrc.pp
@@ -3,7 +3,7 @@ class rvm::rvmrc(
   $template = 'rvm/rvmrc.erb',
   $umask = 'u=rwx,g=rwx,o=rx',
   $max_time_flag = undef,
-  $autoupdate_flag = 0) inherits rvm::params {
+  $autoupdate_flag = '0') inherits rvm::params {
 
   include rvm::group
 


### PR DESCRIPTION
```
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Failed to parse template rvm/rvmrc.erb:
  Filepath: /srv/puppet/forge/rvm/templates/rvmrc.erb
  Line: 7
  Detail: undefined method `empty?' for 0:Fixnum
```
