### PR TITLE
Fix RVM version logging

### DIFF
--- a/manifests/system.pp
+++ b/manifests/system.pp
@@ -28,12 +28,10 @@ class rvm::system(
 
   # the fact won't work until rvm is installed before puppet starts
   if "${::rvm_version}" != "" {
-    notice("RVM version ${::rvm_version}")
-
     if ($version != undef) and ($version != present) and ($version != $::rvm_version) {
       # Update the rvm installation to the version specified
       notify { 'rvm-get_version':
-        message => "RVM updating to version ${version}",
+        message => "RVM updating from version ${::rvm_version} to ${version}",
       }
       exec { 'system-rvm-get':
         path        => '/usr/local/rvm/bin:/usr/bin:/usr/sbin:/bin',


### PR DESCRIPTION
It looks like this got changed from notify to notice a while back to suppress the output if the version didn't change. However that change simply moved the output from the puppet client to the puppet server. This seemed to make the most sense.

For reference:

**notice** is for debug output on the puppet master
**notify** is for debug output on the puppet client
