### PR TITLE
consider not using ensure_resource in system_user.pp

### DIFF
--- a/manifests/system_user.pp
+++ b/manifests/system_user.pp
@@ -1,7 +1,14 @@
-define rvm::system_user () {
+define rvm::system_user (
+  $create=true ) {
+
   include rvm::params
 
+  if $create {
+
   ensure_resource('user', $name, {'ensure' => 'present' })
+
+  }
+
   include rvm::group
 
   $add_to_group = $osfamily ? {


### PR DESCRIPTION
As puppet compiles resources in a non ordered way, I'm getting a duplicate declaration failure when adding system users. I believe this is because the ensure_resource line is being compiled into the catalog before my user resource is. Since user creation most likely happens outside of this module, is it perhaps more generally useful to revert back to something like:

```
if ! defined(User[$name]) {
  user { $name:
  ensure => present;
}
```
