### PR TITLE
Add silence_path_mismatch_check_flag to rvm::rvmrc

### DIFF
--- a/manifests/rvmrc.pp
+++ b/manifests/rvmrc.pp
@@ -3,7 +3,8 @@ class rvm::rvmrc(
   $template = 'rvm/rvmrc.erb',
   $umask = 'u=rwx,g=rwx,o=rx',
   $max_time_flag = undef,
-  $autoupdate_flag = '0') inherits rvm::params {
+  $autoupdate_flag = '0',
+  $silence_path_mismatch_check_flag = undef) inherits rvm::params {
 
   include rvm::group
 

--- a/templates/rvmrc.erb
+++ b/templates/rvmrc.erb
@@ -7,3 +7,6 @@ export rvm_max_time_flag=<%= @max_time_flag %>
 <% if @autoupdate_flag and !@autoupdate_flag.empty? -%>
 rvm_autoupdate_flag=<%= @autoupdate_flag %>
 <% end -%>
+<% if @silence_path_mismatch_check_flag and !@silence_path_mismatch_check_flag.empty? -%>
+rvm_silence_path_mismatch_check_flag=<%= @silence_path_mismatch_check_flag %>
+<%end -%>


### PR DESCRIPTION
I need to configure this particular option and was unable to do so
as it wasn’t explicitly included.
