### PR TITLE
Quote bare word upper case words in case statements

### DIFF
--- a/manifests/dependencies.pp
+++ b/manifests/dependencies.pp
@@ -1,8 +1,8 @@
 class rvm::dependencies {
   case $::operatingsystem {
-    Ubuntu,Debian: { require rvm::dependencies::ubuntu }
-    CentOS,RedHat,Fedora,rhel,Amazon,Scientific: { require rvm::dependencies::centos }
-    OracleLinux: { require rvm::dependencies::oraclelinux }
+    'Ubuntu','Debian': { require rvm::dependencies::ubuntu }
+    'CentOS','RedHat','Fedora','rhel','Amazon','Scientific': { require rvm::dependencies::centos }
+    'OracleLinux': { require rvm::dependencies::oraclelinux }
     default: {}
   }
 }

--- a/manifests/passenger/dependencies.pp
+++ b/manifests/passenger/dependencies.pp
@@ -1,8 +1,8 @@
 class rvm::passenger::dependencies {
   case $::operatingsystem {
-    Ubuntu,Debian: { require rvm::passenger::dependencies::ubuntu }
-    CentOS,RedHat,Fedora,rhel,Amazon,Scientific: { require rvm::passenger::dependencies::centos }
-    OracleLinux: { require rvm::passenger::dependencies::oraclelinux }
+    'Ubuntu','Debian': { require rvm::passenger::dependencies::ubuntu }
+    'CentOS','RedHat','Fedora','rhel','Amazon','Scientific': { require rvm::passenger::dependencies::centos }
+    'OracleLinux': { require rvm::passenger::dependencies::oraclelinux }
     default: {}
   }
 }

--- a/manifests/system.pp
+++ b/manifests/system.pp
@@ -11,7 +11,7 @@ class rvm::system(
   # curl needs to be installed
   if ! defined(Package['curl']) {
     case $::kernel {
-      Linux: {
+      'Linux': {
         ensure_packages(['curl'])
         Package['curl'] -> Exec['system-rvm']
       }


### PR DESCRIPTION
Bare word upper case words are reserved in puppet 3 future parser and puppet 4.

If you use the future parser, this breaks.  See the following for more details:
https://tickets.puppetlabs.com/browse/PUP-2800
