### PR TITLE
Add options to opt out of rvmrc/group management

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,6 +2,8 @@ class rvm(
   $version=undef,
   $install_rvm=true,
   $install_dependencies=false,
+  $manage_rvmrc=true,
+  $manage_group=true,
   $system_users=[],
   $system_rubies={},
   $proxy_url=$rvm::params::proxy_url) inherits rvm::params {
@@ -15,7 +17,9 @@ class rvm(
       }
     }
 
-    ensure_resource('class', 'rvm::rvmrc')
+    if $manage_rvmrc {
+      ensure_resource('class', 'rvm::rvmrc')
+    }
 
     class { 'rvm::system':
       version   => $version,

--- a/manifests/rvmrc.pp
+++ b/manifests/rvmrc.pp
@@ -1,12 +1,13 @@
 # Configure the /etc/rvmrc file
 class rvm::rvmrc(
+  $manage_group = $rvm::manage_group,
   $template = 'rvm/rvmrc.erb',
   $umask = 'u=rwx,g=rwx,o=rx',
   $max_time_flag = undef,
   $autoupdate_flag = '0',
   $silence_path_mismatch_check_flag = undef) inherits rvm::params {
 
-  include rvm::group
+  if $manage_group { include rvm::group }
 
   file { '/etc/rvmrc':
     content => template($template),


### PR DESCRIPTION
I have some declarations that cannot be resolved by the use of ensure_resource.
In particular, resources in defined types seem to be parsed last no matter what order you declare the defined type resource in.

For this reason, I would like options to not manage the rvm group, so that It can be managed elsewhere.
