### PR TITLE
Added gpg key import

### DIFF
--- a/manifests/system.pp
+++ b/manifests/system.pp
@@ -27,7 +27,7 @@ class rvm::system(
 
   exec { 'system-rvm':
     path        => '/usr/bin:/usr/sbin:/bin',
-    command     => "/usr/bin/curl -fsSL https://get.rvm.io | bash -s -- --version ${actual_version}",
+    command     => "/usr/bin/gpg2 --keyserver hkp://keys.gnupg.net --recv-keys D39DC0E3 && /usr/bin/curl -fsSL https://get.rvm.io | bash -s -- --version ${actual_version}",
     creates     => '/usr/local/rvm/bin/rvm',
     environment => $proxy_environment,
   }


### PR DESCRIPTION
RVM installs failed on CentOS 6 because the install script couldn't verify the GPG sig. Added key import to the curl install line. Used && to ensure that Puppet will get a fail code and not try to install RVM without the imported keys.
