### PR TITLE
Regexp whole line

### DIFF
--- a/lib/puppet/provider/rvm_system_ruby/rvm_system_ruby.rb
+++ b/lib/puppet/provider/rvm_system_ruby/rvm_system_ruby.rb
@@ -21,7 +21,7 @@ Puppet::Type.type(:rvm_system_ruby).provide(:rvm) do
   def exists?
     begin
       rvmcmd("list", "strings").split("\n").any? do |line|
-        line =~ Regexp.new(/^resource[:name]/)
+        line =~ Regexp.new(/^resource[:name]$/)
       end
     rescue Puppet::ExecutionFailure => detail
       raise Puppet::Error, "Could not list RVMs: #{detail}"
@@ -32,7 +32,7 @@ Puppet::Type.type(:rvm_system_ruby).provide(:rvm) do
   def default_use
     begin
       rvmcmd("list", "default").split("\n").any? do |line|
-        line =~ Regexp.new(/^resource[:name]/)
+        line =~ Regexp.new(/^resource[:name]$/)
       end
     rescue Puppet::ExecutionFailure => detail
       raise Puppet::Error, "Could not list default RVM: #{detail}"


### PR DESCRIPTION
I was constantly running into issues when using this Puppet module (using `puppet apply`) inside a Ruby project folder containing `.ruby-version` file. RVM parses this file while checking what version of Ruby it should use and sadly, it also does that while running `/usr/local/rvm/bin/rvm`. The problem is that, if Ruby version defined in `.ruby-version` is not installed, current version of RVM Puppet module will not detect that, because calling `/usr/local/rvm/bin/rvm` from inside a Ruby project folder would give something like this:

```
ernestas@vbox-ubuntu:~/ss$ /bin/sh -c '/usr/local/rvm/bin/rvm list strings'
ruby-2.3.0 is not installed.
To install do: 'rvm install ruby-2.3.0'
ernestas@vbox-ubuntu:~/ss$ 
```

Not only that, it can produce other warnings like:

```
$ rvm list strings
Warning! PATH is not properly set up, '/usr/local/rvm/gems/ruby-2.3.1/bin' is not at first place,
         usually this is caused by shell initialization files - check them for 'PATH=...' entries,
         it might also help to re-add RVM to your dotfiles: 'rvm get stable --auto-dotfiles',
         to fix temporarily in this shell session run: 'rvm use ruby-2.3.1'.
ruby-2.3.1
$ 
```

Sadly, not all of the warnings go to stderr, thus, it's not an option to just ignore stderr. We need to check for Ruby versions only from the beginning of a line.
