### PR TITLE
Simplify the way we ensure curl

### DIFF
--- a/manifests/system.pp
+++ b/manifests/system.pp
@@ -14,17 +14,6 @@ class rvm::system(
     default   => $version,
   }
 
-  # curl needs to be installed
-  if ! defined(Package['curl']) {
-    case $::kernel {
-      'Linux': {
-        ensure_packages(['curl'])
-        Package['curl'] -> Exec['system-rvm']
-      }
-      default: { }
-    }
-  }
-
   $http_proxy_environment = $proxy_url ? {
     undef   => [],
     default => ["http_proxy=${proxy_url}", "https_proxy=${proxy_url}"]
@@ -67,11 +56,13 @@ class rvm::system(
 
   }
   else {
+    ensure_packages(['curl'])
     exec { 'system-rvm':
       path        => '/usr/bin:/usr/sbin:/bin:/usr/local/bin',
       command     => "curl -fsSL https://get.rvm.io | bash -s -- --version ${actual_version}",
       creates     => '/usr/local/rvm/bin/rvm',
       environment => $environment,
+      require     => [Package['curl']],
     }
   }
 


### PR DESCRIPTION
At the moment if the package curl is already defined somewhere else, the dependency between system-rvm and curl isn't set properly.

Also there is no point in checking whether the package curl defined before doing an ensure packages.

Instead, just before doing the curl, we do an ensure packages (this way we only do it when necessary), and now the system-rvm exec requires the curl package.
