### PR TITLE
Chain of exec's instead of curl | bash

### DIFF
--- a/manifests/system.pp
+++ b/manifests/system.pp
@@ -19,7 +19,7 @@ class rvm::system(
     case $::kernel {
       'Linux': {
         ensure_packages(['curl'])
-        Package['curl'] -> Exec['system-rvm']
+        Package['curl'] -> Class['rvm::verified_install']
       }
       default: { }
     }
@@ -41,7 +41,7 @@ class rvm::system(
     class { 'rvm::gnupg_key':
       key_server => $key_server,
       key_id     => $gnupg_key_id,
-      before     => Exec['system-rvm'],
+      before     => Class['rvm::verified_install'],
     }
   }
 
@@ -67,11 +67,9 @@ class rvm::system(
 
   }
   else {
-    exec { 'system-rvm':
-      path        => '/usr/bin:/usr/sbin:/bin:/usr/local/bin',
-      command     => "curl -fsSL https://get.rvm.io | bash -s -- --version ${actual_version}",
-      creates     => '/usr/local/rvm/bin/rvm',
-      environment => $environment,
+    class { 'rvm::verified_install':
+      environment    => $environment,
+      actual_version => $actual_version,
     }
   }
 
@@ -90,7 +88,7 @@ class rvm::system(
       exec { 'system-rvm-get':
         path        => '/usr/local/rvm/bin:/usr/bin:/usr/sbin:/bin',
         command     => "rvm get ${version}",
-        before      => Exec['system-rvm'], # so it doesn't run after being installed the first time
+        before      => Class['rvm::verified_install'], # so it doesn't run after being installed the first time
         environment => $environment,
       }
     }

--- a/manifests/verified_install.pp
+++ b/manifests/verified_install.pp
@@ -1,0 +1,28 @@
+# Encapsuate the initial installation and an obligatory verification
+class rvm::verified_install (
+  # These are passed from rvm::system
+  $environment=undef,
+  $actual_version=undef) {
+    Exec {
+      path        => '/usr/bin:/usr/sbin:/bin:/usr/local/bin',
+      environment => $environment,
+      unless      => 'test -e  /usr/local/rvm/bin/rvm',
+    }
+    exec { 'download-detached-key':
+      command     => "curl -sf https://raw.githubusercontent.com/rvm/rvm/master/binscripts/rvm-installer.asc > /tmp/rvm-installer.asc",
+    }->
+    # I thought of feeding curl output to gpg in order to remove less files during
+    # cleanup, but let's run exactly the file we've verified
+    exec { 'download-installer':
+      command     => "curl -sf https://raw.githubusercontent.com/rvm/rvm/master/binscripts/rvm-installer > /tmp/rvm-installer",
+    }->
+    exec { 'verify-installer':
+      command     => "gpg --verify /tmp/rvm-installer.asc /tmp/rvm-installer",
+    }->
+    exec { 'run-installer':
+      command     => "bash /tmp/rvm-installer --version ${actual_version}",
+    }->
+    exec { 'cleanup-tmp':
+      command     => "rm /tmp/rvm-installer{,.asc}",
+    }
+}


### PR DESCRIPTION
If I understand correctly, the module currently relies on a script it downloads to call for verification.

I propose to download the installer and the detached key, verify and install as described here: https://rvm.io/rvm/security instead.

It is a bit procedural and maybe not the best style but it beats piping unverified code to bash IMO.