### PR TITLE
Update deprecated install options, and strip default string from gem output

### DIFF
--- a/lib/puppet/provider/rvm_gem/gem.rb
+++ b/lib/puppet/provider/rvm_gem/gem.rb
@@ -58,10 +58,11 @@ Puppet::Type.type(:rvm_gem).provide(:gem) do
   end
 
   def self.gemsplit(desc)
+    desc = desc.gsub('default: ', '')
+
     case desc
     when %r{^\*\*\*}, %r{^\s*$}, %r{^\s+} then return nil
     when %r{gem: not found} then nil
-    # when /^(\S+)\s+\((((((\d+[.]?))+)(,\s)*)+)\)/
     when %r{^(\S+)\s+\((\d+.*)\)}
       name = Regexp.last_match(1)
       version = Regexp.last_match(2).split(%r{,\s*})

--- a/lib/puppet/provider/rvm_gem/gem.rb
+++ b/lib/puppet/provider/rvm_gem/gem.rb
@@ -14,6 +14,11 @@ Puppet::Type.type(:rvm_gem).provide(:gem) do
     resource[:ruby_version]
   end
 
+  def rubygems_version
+    command = gembinary + ['-v']
+    execute(command)
+  end
+
   def gembinary
     [command(:rvmcmd), ruby_version, 'do', 'gem']
   end
@@ -102,7 +107,11 @@ Puppet::Type.type(:rvm_gem).provide(:gem) do
         command << '--source' << source.to_s << resource[:name]
       end
     else
-      command << '--no-rdoc' << '--no-ri' << resource[:name]
+      if Gem::Version.new(rubygems_version) < Gem::Version.new('3.0.0')
+        command << '--no-rdoc' << '--no-ri' << resource[:name] # Deprecated options (backwards compatible)
+      else
+        command << '--no-document' << resource[:name]
+      end
     end
 
     # makefile opts,


### PR DESCRIPTION
Closes #141

- Update install options to determine rubygems version, and remove deprecated `--no-ri` and `--no-rdoc` if rubygems >= 3.0.0 in favor of `--no-document`

- Strip `default: ` string from gem output before regexing it.  I've found in various cases that there can be multiple instances of the string, so decided to remove all occurrences vs. updating existing regex (open to other suggestions).  Example:

```
rvm 2.6.5 do gem list ^bundler$

*** LOCAL GEMS ***

bundler (default: 2.1.2, 1.17.3)
```
