### PR TITLE
Update `gem install` CLI options

### DIFF
--- a/lib/puppet/provider/rvm_gem/gem.rb
+++ b/lib/puppet/provider/rvm_gem/gem.rb
@@ -109,7 +109,7 @@ Puppet::Type.type(:rvm_gem).provide(:gem) do
         command << "--source" << "#{source}" << resource[:name]
       end
     else
-      command << "--no-rdoc" << "--no-ri" <<  resource[:name]
+      command << "--no-document" <<  resource[:name]
     end
 
     # makefile opts,


### PR DESCRIPTION
gem 3.0 dropped support for `--no-rdoc --no-ri`.
We must use `--no-document` instead.