### PR TITLE
Rubocop: Fix Lint/HandleExceptions

### DIFF
--- a/lib/puppet/provider/rvm_alias/alias.rb
+++ b/lib/puppet/provider/rvm_alias/alias.rb
@@ -25,6 +25,7 @@ Puppet::Type.type(:rvm_alias).provide(:alias) do
     begin
       list = execute(command)
     rescue Puppet::ExecutionFailure => detail
+      Puppet.debug "`rvmcmd` command failed with #{detail}"
     end
 
     list.to_s

--- a/lib/puppet/provider/rvm_gem/gem.rb
+++ b/lib/puppet/provider/rvm_gem/gem.rb
@@ -45,6 +45,7 @@ Puppet::Type.type(:rvm_gem).provide(:gem) do
         end
       end.compact
     rescue Puppet::ExecutionFailure => detail
+      Puppet.debug "`rvmcmd` command failed with #{detail}"
     end
 
     if hash[:justme]

--- a/lib/puppet/provider/rvm_gemset/gemset.rb
+++ b/lib/puppet/provider/rvm_gemset/gemset.rb
@@ -36,6 +36,7 @@ Puppet::Type.type(:rvm_gemset).provide(:gemset) do
         line.strip if line =~ %r{^\s+\S+}
       end.compact
     rescue Puppet::ExecutionFailure => detail
+      Puppet.debug "`rvmcmd` command failed with #{detail}"
     end
 
     list


### PR DESCRIPTION
This simultaneously fixes `Lint/UselessAssignment` as we're now making use of the `detail` variables.