### PR TITLE
Drop AIX support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -84,14 +84,6 @@
       ]
     },
     {
-      "operatingsystem": "AIX",
-      "operatingsystemrelease": [
-        "5.3",
-        "6.1",
-        "7.1"
-      ]
-    },
-    {
       "operatingsystem": "Darwin",
       "operatingsystemrelease": [
         "10",


### PR DESCRIPTION
The gnupg module doesn't support AIX and we also cannot test on AIX.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
