### PR TITLE
Drop Windows support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -71,19 +71,6 @@
       ]
     },
     {
-      "operatingsystem": "Windows",
-      "operatingsystemrelease": [
-        "Server 2003",
-        "Server 2003 R2",
-        "Server 2008",
-        "Server 2008 R2",
-        "Server 2012",
-        "Server 2012 R2",
-        "7",
-        "8"
-      ]
-    },
-    {
       "operatingsystem": "Darwin",
       "operatingsystemrelease": [
         "10",


### PR DESCRIPTION
The gnupg module doesn't support windows. Also we cannot run tests on
windows.. This is cherry-picked from #164 

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
