### PR TITLE
Drop Solaris support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -64,13 +64,6 @@
       ]
     },
     {
-      "operatingsystem": "Solaris",
-      "operatingsystemrelease": [
-        "10",
-        "11"
-      ]
-    },
-    {
       "operatingsystem": "Darwin",
       "operatingsystemrelease": [
         "10",


### PR DESCRIPTION
Solaris is not supported by the gnupg module and we cannot test it.
cherry-picked from #164

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
