### PR TITLE
Perform full line matching in rvm_system_ruby

### DIFF
--- a/lib/puppet/provider/rvm_system_ruby/rvm_system_ruby.rb
+++ b/lib/puppet/provider/rvm_system_ruby/rvm_system_ruby.rb
@@ -21,17 +21,13 @@ Puppet::Type.type(:rvm_system_ruby).provide(:rvm) do
   end
 
   def exists?
-    rvmcmd('list', 'strings').split("\n").any? do |line|
-      line =~ Regexp.new(Regexp.escape(resource[:name]))
-    end
+    rvmcmd('list', 'strings').split("\n").include?(resource[:name])
   rescue Puppet::ExecutionFailure => e
     raise Puppet::Error, "Could not list RVMs: #{e}"
   end
 
   def default_use
-    rvmcmd('list', 'default').split("\n").any? do |line|
-      line =~ Regexp.new(Regexp.escape(resource[:name]))
-    end
+    rvmcmd('list', 'default').split("\n").include?(resource[:name])
   rescue Puppet::ExecutionFailure => e
     raise Puppet::Error, "Could not list default RVM: #{e}"
   end


### PR DESCRIPTION
Rather than seeing if the line contains the name this checks if the whole line matches. This can also avoid problems where ruby-x.y.1 could match ruby-x.y.10.

Replacement for https://github.com/voxpupuli/puppet-rvm/pull/124. I'm relying on CI to tell me if this is a good change.