### PR TITLE
Updating rvm_version fact regex

### DIFF
--- a/lib/facter/rvm_version.rb
+++ b/lib/facter/rvm_version.rb
@@ -4,6 +4,6 @@ Facter.add(:rvm_version) do
   rvm_binary = '/usr/local/rvm/bin/rvm'
 
   setcode do
-    File.exist?(rvm_binary) ? `#{rvm_binary} version`.strip.match(%r{rvm ([0-9]+\.[0-9]+\.[0-9]+) .*})[1] : nil
+    File.exist?(rvm_binary) ? `#{rvm_binary} version`.strip.match(%r{rvm ([0-9]+\.[0-9]+\.[0-9]+)(?:-next)? .*})[1] : nil
   end
 end


### PR DESCRIPTION
#### Pull Request (PR) description
Updating rvm_version fact regex to account for master `-next` version tag based on https://github.com/rvm/rvm/blob/35e894c7070eaabc38d91220f6e26d1585a7098a/docs/release-procedure.md

#### This Pull Request (PR) fixes the following issues
Fixes #189 
