### PR TITLE
Fix broken logic for gpg keys

### DIFF
--- a/manifests/system.pp
+++ b/manifests/system.pp
@@ -24,7 +24,7 @@ class rvm::system (
   $proxy_environment = concat($http_proxy_environment, $no_proxy_environment)
   $environment = concat($proxy_environment, ["HOME=${home}"])
 
-  if $signing_keys {
+  unless empty($signing_keys) {
     include gnupg
 
     # https keys are downloaded with wget


### PR DESCRIPTION
Previously we checked if $signing_keys is defined / not undef. That's always the case. The datatype enforces that it's an array. We need to check if it's not empty.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
