### PR TITLE
Drop OracleLinux support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -34,13 +34,6 @@
       ]
     },
     {
-      "operatingsystem": "OracleLinux",
-      "operatingsystemrelease": [
-        "7",
-        "8"
-      ]
-    },
-    {
       "operatingsystem": "Scientific",
       "operatingsystemrelease": [
         "7"


### PR DESCRIPTION
While running acceptance tests it proved that it couldn't install.